### PR TITLE
Update flatpak build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sudo pacman -S flatpak-builder
 
 ### Add flathub repository
 ```
-flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 ```
 
 ### Build and install container


### PR DESCRIPTION
I am building on Fedora 43 and found I needed to tweak the commands to successfully do a flatpak build:

* Ensure the flathub repo is added to the per-user installation, since flatpak-builder installs the dependencies in the per-user installation.