### PR TITLE
Update autogen script on virtualenv part

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -865,33 +865,31 @@ setupPythonVirtualEnv(){
     VENV_EXEC="virtualenv"
   fi
 
-  local VENV_DIR="./venvfolder"
-  local VENV_ACTIVATE="$VENV_DIR/bin/activate"
-  if [ -f "$VENV_DIR/local/bin/activate" ]; then
-    VENV_ACTIVATE="$VENV_DIR/local/bin/activate"
-  fi
-
-  #Setting up Virtual Python environment
-  if [ ! -f "$VENV_ACTIVATE" ]; then
-    $VENV_EXEC "$VENV_DIR" 2>&1 | printlines project="virtualenv" task="setup"
+  # Setting up Virtual Python environment
+  if [ ! -f "./venvfolder/bin/activate" ] && [ ! -f "./venvfolder/local/bin/activate" ]; then
+    $VENV_EXEC ./venvfolder 2>&1 | printlines project="virtualenv" task="setup"
     if [ "${PIPESTATUS[0]}" -ne 0 ]; then
       printError project="virtualenv" task="setup" msg="failed to run python3 virtualenv.pyz"
       exit 1;
-    fi
-    VENV_ACTIVATE="$VENV_DIR/bin/activate"
-    if [ -f "$VENV_DIR/local/bin/activate" ]; then
-      VENV_ACTIVATE="$VENV_DIR/local/bin/activate"
     fi
   else
     printlines project="virtualenv" task="check" msg="found"
   fi
 
-  #Activate virtual environment
-  if [[ ! -f "$VENV_ACTIVATE" ]]; then
+  # Activate virtual environment
+  ACTIVATE=""
+
+  if [ -f "./venvfolder/bin/activate" ]; then
+    ACTIVATE="./venvfolder/bin/activate"
+  elif [ -f "./venvfolder/local/bin/activate" ]; then
+    ACTIVATE="./venvfolder/local/bin/activate"
+  fi
+
+  if [ -z "$ACTIVATE" ]; then
     printError project="virtualenv" task="activate" msg="failed to activate python virtual environment."
     exit 1;
   else
-    source "$VENV_ACTIVATE"
+    source "$ACTIVATE"
     printlines project="virtualenv" task="activate" msg="activated python virtual environment."
   fi
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -865,23 +865,33 @@ setupPythonVirtualEnv(){
     VENV_EXEC="virtualenv"
   fi
 
+  local VENV_DIR="./venvfolder"
+  local VENV_ACTIVATE="$VENV_DIR/bin/activate"
+  if [ -f "$VENV_DIR/local/bin/activate" ]; then
+    VENV_ACTIVATE="$VENV_DIR/local/bin/activate"
+  fi
+
   #Setting up Virtual Python environment
-  if [ ! -f "./venvfolder/bin/activate" ]; then
-    $VENV_EXEC ./venvfolder 2>&1 | printlines project="virtualenv" task="setup"
+  if [ ! -f "$VENV_ACTIVATE" ]; then
+    $VENV_EXEC "$VENV_DIR" 2>&1 | printlines project="virtualenv" task="setup"
     if [ "${PIPESTATUS[0]}" -ne 0 ]; then
       printError project="virtualenv" task="setup" msg="failed to run python3 virtualenv.pyz"
       exit 1;
+    fi
+    VENV_ACTIVATE="$VENV_DIR/bin/activate"
+    if [ -f "$VENV_DIR/local/bin/activate" ]; then
+      VENV_ACTIVATE="$VENV_DIR/local/bin/activate"
     fi
   else
     printlines project="virtualenv" task="check" msg="found"
   fi
 
   #Activate virtual environment
-  if [[ ! -f "venvfolder/bin/activate" ]]; then
+  if [[ ! -f "$VENV_ACTIVATE" ]]; then
     printError project="virtualenv" task="activate" msg="failed to activate python virtual environment."
     exit 1;
   else
-    source venvfolder/bin/activate 
+    source "$VENV_ACTIVATE"
     printlines project="virtualenv" task="activate" msg="activated python virtual environment."
   fi
 


### PR DESCRIPTION
Got this error on Pop OS 22.04, so this fixed it
```
./autogen.sh --prefix=$(pwd)/dist --enable-latest
make check found
g++ check found
git check found
tar check found
wget check found
wget check version is too old. 1.21.2 < 2..
wget check found
unbuffer check not found
pkg-config check found
gtk3 check found
m4 check found
autoconf check found
automake check found
libtool check found
flex check found
bison check found
virtualenv check found
virtualenv setup created virtual environment CPython3.10.12.final.0-64 in 198ms
virtualenv setup   creator CPython3Posix(dest=/home/mhz/Git/OnvifDeviceManager/subprojects/venvfolder, clear=False, no_vcs_ignore=False, global=False)
virtualenv setup   seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/mhz/.local/share/virtualenv)
virtualenv setup     added seed packages: pip==22.0.2, setuptools==59.6.0, wheel==0.37.1
virtualenv setup   activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
virtualenv activate *****************************
virtualenv activate *  failed to activate python virtual environment.
virtualenv activate *  Kernel: 6.17.9-76061709-generic
virtualenv activate *  Kernel: x86_64
virtualenv activate *****************************
```